### PR TITLE
Feat: Add daily cron job for subscription downgrades

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -2,9 +2,14 @@
 builder = "NIXPACKS"
 
 [deploy]
-# Run your app with gunicorn, pointing to run:create_app()
-startCommand = "gunicorn 'run:create_app()' --bind 0.0.0.0:$PORT"
+# Run your app with gunicorn, pointing to run:app
+startCommand = "gunicorn run:app --bind 0.0.0.0:$PORT"
 
 # Run migrations automatically after each deploy
 [[deploy.hooks]]
 command = "flask db upgrade"
+
+# Cron job to handle expired subscriptions daily at midnight
+[cron]
+schedule = "0 0 * * *"
+command = "flask subscriptions:downgrade"


### PR DESCRIPTION
This commit adds a cron job configuration to `railway.toml` to automatically manage expired subscriptions.

- A `[cron]` block has been added to schedule the `flask subscriptions:downgrade` command to run daily at midnight (`0 0 * * *`).
- This automates the process of downgrading users whose subscriptions have passed their grace period.
- The `startCommand` in `railway.toml` was also corrected to ensure the application deploys correctly.