### PR TITLE
Feat: Add explicit payment channels to Paystack API call

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -140,7 +140,8 @@ def subscribe(plan_id):
         email=current_user.email,
         amount=plan.price,
         plan=plan.paystack_plan_code,
-        callback_url=url_for('main.dashboard', _external=True)
+        callback_url=url_for('main.dashboard', _external=True),
+        channels=['card', 'bank', 'ussd', 'qr']
     )
 
     if transaction['status']:


### PR DESCRIPTION
This commit updates the Paystack integration to explicitly specify the payment channels that should be available to the user during checkout.

- The `Transaction.initialize` call in `app/main/routes.py` now includes a `channels` parameter.
- This parameter is set to `['card', 'bank', 'ussd', 'qr']` to give users multiple options to complete their payment, resolving an issue where only the 'card' option was being displayed.