### PR TITLE
feat: Display user initials as profile picture fallback

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -71,6 +71,15 @@ class User(UserMixin, db.Model):
             return self.active_subscription.plan.name
         return 'Free'
 
+    def get_initials(self):
+        if not self.username:
+            return ""
+        name_parts = self.username.split()
+        if len(name_parts) > 1:
+            return (name_parts[0][0] + name_parts[-1][0]).upper()
+        else:
+            return self.username[0].upper()
+
     def __repr__(self):
         return '<User {}>'.format(self.username)
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -196,3 +196,33 @@ body {
     z-index: 999;
     border-bottom: 1px solid #FDE68A;
 }
+
+/* Profile Initials */
+.profile-initials-large {
+    width: 150px;
+    height: 150px;
+    border-radius: 50%;
+    background-color: #eee;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: auto;
+    margin-bottom: 20px;
+    font-size: 50px;
+    color: #333;
+    font-weight: bold;
+}
+
+.profile-initials-small {
+    display: inline-block;
+    vertical-align: middle;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    background-color: #eee;
+    text-align: center;
+    line-height: 30px;
+    font-size: 12px;
+    color: #333;
+    font-weight: bold;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -30,7 +30,13 @@
                     <li><a href="{{ url_for('auth.logout') }}">Logout</a></li>
                     <li>
                         <a href="{{ url_for('main.edit_profile') }}">
-                            <img src="{{ url_for('static', filename='profile_pics/' + current_user.profile_picture) }}" alt="My Profile Picture" style="width: 30px; height: 30px; border-radius: 50%; object-fit: cover; vertical-align: middle;">
+                            {% if current_user.profile_picture == 'default.jpg' %}
+                                <div class="profile-initials-small">
+                                    {{ current_user.get_initials() }}
+                                </div>
+                            {% else %}
+                                <img src="{{ url_for('static', filename='profile_pics/' + current_user.profile_picture) }}" alt="My Profile Picture" style="width: 30px; height: 30px; border-radius: 50%; object-fit: cover; vertical-align: middle;">
+                            {% endif %}
                         </a>
                     </li>
                 {% endif %}

--- a/app/templates/public_profile.html
+++ b/app/templates/public_profile.html
@@ -6,7 +6,13 @@
 
 {% block content %}
 <div class="profile-card" style="text-align: center;">
+    {% if user.profile_picture == 'default.jpg' %}
+    <div class="profile-initials-large">
+        {{ user.get_initials() }}
+    </div>
+    {% else %}
     <img src="{{ url_for('static', filename='profile_pics/' + user.profile_picture) }}" alt="Profile Picture" style="width: 150px; height: 150px; border-radius: 50%; object-fit: cover; margin-bottom: 20px;">
+    {% endif %}
     <h1>@{{ user.username }}</h1>
 
     {% if user.bio %}


### PR DESCRIPTION
This commit implements a feature to display user initials as a fallback for their profile picture if they haven't uploaded one yet.

- A `get_initials` method has been added to the `User` model to generate initials from the username.
- CSS styles have been added for displaying these initials in both large and small formats.
- The `base.html` and `public_profile.html` templates have been updated to conditionally display either the user's profile picture or their initials.